### PR TITLE
Ask the EntityManager for the ClassMetadata object instead of newing it up

### DIFF
--- a/orm/repositories.md
+++ b/orm/repositories.md
@@ -50,7 +50,7 @@ public function register()
     $this->app->bind(ArticleRepository::class, function($app) {
         return new DoctrineArticleRepository(
             $app['em'],
-            new ClassMetaData(Article::class)
+            $app['em']->getClassMetadata(Article::class)
         );
     });
 }


### PR DESCRIPTION
Recommend this as default way of getting a class' metadata. It is what Doctrine does in its `DefaultRepositoryFactory` anyway.
