### PR TITLE
Adding detail for using config file metadata

### DIFF
--- a/orm/meta-data.md
+++ b/orm/meta-data.md
@@ -98,8 +98,19 @@ More information about XML mappings: http://doctrine-orm.readthedocs.org/en/late
 
 ### Config files
 
-This package adds another option, which leverages Laravel's config system. You could for example create a `config/mappings.php` file and set that inside the `mapping_file` setting.
-The array structure is almost identical to the YAML one:
+This package adds another option, which leverages Laravel's config system. In addition to setting `meta`, this also requires setting `mapping_file`. You could for example create a `config/mappings.php` file to provide mapping information. Here is an example of setting the `meta` and `mapping_file` config properties inside of `config/doctrine.php` to use config file-based metadata:
+
+```php
+<?php
+
+return [
+    'managers' => [
+        'default' => [
+            'meta'       => env('DOCTRINE_METADATA', 'config'),
+            'mapping_file' => 'mappings',
+```
+
+The array structure in `config/mappings.php` is almost identical to the YAML one:
 
 ```php
 <?php


### PR DESCRIPTION
Making it more explicit how to set mapping_file in order to use config-based metadata. I totally missed that the mapping_file setting needed to be set in doctrine.php when I first tried it.
