### PR TITLE
Add missing semicolon to auth example code

### DIFF
--- a/orm/auth.md
+++ b/orm/auth.md
@@ -42,7 +42,7 @@ You may also use the provided trait `LaravelDoctrine\ORM\Auth\Authenticatable` i
 ```
 class User implements \LaravelDoctrine\ORM\Contracts\Auth\Authenticatable
 {
-    use \LaravelDoctrine\ORM\Auth\Authenticatable
+    use \LaravelDoctrine\ORM\Auth\Authenticatable;
     
     /**
      * @ORM\Id


### PR DESCRIPTION
Pointed out by user drecken on the slack.
