### PR TITLE
Recommend users to create a dedicated Entities folder.

### DIFF
--- a/orm/installation.md
+++ b/orm/installation.md
@@ -32,3 +32,14 @@ php artisan vendor:publish --tag="config"
 ```
 
 Available environment variables inside the config are: `APP_DEBUG`, `DOCTRINE_METADATA`, `DB_CONNECTION`, `DOCTRINE_PROXY_AUTOGENERATE`, `DOCTRINE_LOGGER` and `DOCTRINE_CACHE`
+
+> Important:
+> By default, Laravel's application skeleton has its `Model` classes in the `app/` folder. With Doctrine, you'll need to
+> create a dedicated folder for your `Entities` and point your `config/doctrine.php` `paths` array to it.
+> If you don't, Doctrine will scan your whole `app/` folder for files, which will have a huge impact on performance!
+> 
+> ```
+> 'paths' => [
+>     base_path('app/Entities'),
+> ],
+> ```


### PR DESCRIPTION
Advanced users will know to ignore this, but beginners are facing this problem all the time. 
