### PR TITLE
Custom types keys should be lowercase

### DIFF
--- a/extensions/custom-functions.md
+++ b/extensions/custom-functions.md
@@ -25,10 +25,10 @@ return [
     |--------------------------------------------------------------------------
     */
     'custom_types'              => [
-        'CarbonDate'       => DoctrineExtensions\Types\CarbonDateType::class,
-        'CarbonDateTime'   => DoctrineExtensions\Types\CarbonDateTimeType::class,
-        'CarbonDateTimeTz' => DoctrineExtensions\Types\CarbonDateTimeTzType::class,
-        'CarbonTime'       => DoctrineExtensions\Types\CarbonTimeType::class
+        'carbondate'       => DoctrineExtensions\Types\CarbonDateType::class,
+        'carbondatetime'   => DoctrineExtensions\Types\CarbonDateTimeType::class,
+        'carbondatetimetz' => DoctrineExtensions\Types\CarbonDateTimeTzType::class,
+        'carbontime'       => DoctrineExtensions\Types\CarbonTimeType::class
     ],
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Fix laravel-doctrine/fluent#39 : custom types config keys should be lowercase
