### PR TITLE
Closure argument for $connections->extend(...) differed from used arguments.

### DIFF
--- a/orm/connections.md
+++ b/orm/connections.md
@@ -17,7 +17,7 @@ You can replace existing connection drivers or add custom drivers using the `Lar
 
 ```php
 public function boot(ConnectionManager $cache) {
-    $connections->extend('myDriver', function(Application $app) {
+    $connections->extend('myDriver', function(array $settings, \Illuminate\Contracts\Container\Container $container) {
         return [
             'driver' => 'driver',
             'host'   => ...


### PR DESCRIPTION
The arguments to extend the connectionManager differs from the ones used in the documention. 

The ones sent in my setup are the settings and the container. This might also be the case for the other extend Closures.