### PR TITLE
Create default-table-options.md

### DIFF
--- a/orm/default-table-options.md
+++ b/orm/default-table-options.md
@@ -1,0 +1,34 @@
+# Default Table Options
+
+You can set default table options for your database connections.
+
+Modify your `database.php` configuration file to include the `defaultTableOptions` key
+
+# Example
+for a MySQL databse
+```php
+  ...
+      'mysql' => [
+          'driver' => 'mysql',
+          'host' => env('DB_HOST', '127.0.0.1'),
+          'port' => env('DB_PORT', '3306'),
+          'database' => env('DB_DATABASE', 'forge'),
+          'username' => env('DB_USERNAME', 'forge'),
+          'password' => env('DB_PASSWORD', ''),
+          'unix_socket' => env('DB_SOCKET', ''),
+          'defaultTableOptions' => [
+              'charset' => 'utf8mb4',
+              'collate' => 'utf8mb4_unicode_ci'
+          ],
+          'charset' => 'utf8mb4', // This will be the charset for the connection
+          'prefix' => '',
+          'strict' => true,
+          'engine' => null,
+      ],
+  ...
+```
+
+Property | Explaination
+---- | ----
+charset | Tables will be created with `CHARACTER SET utf8` by default *Even If* your database is set up with it's own default character set. Setting this property will ensure new tables are created with the given encoding
+collate | As above, this must be edited if you with your collation to be anything other than utf8_unicode_ci


### PR DESCRIPTION
Documentation is needed for `defaultTableOptions`.
I'm only aware of `charset` and `collate` through trial and error so more work is needed