### PR TITLE
Remove Migrations Composer Require Version

### DIFF
--- a/migrations/installation.md
+++ b/migrations/installation.md
@@ -3,7 +3,7 @@
 Install this package with composer:
 
 ```
-composer require "laravel-doctrine/migrations:1.0.*"
+composer require "laravel-doctrine/migrations"
 ```
 
 After updating composer, add the ServiceProvider to the providers array in `config/app.php`

--- a/migrations/lumen.md
+++ b/migrations/lumen.md
@@ -5,7 +5,7 @@ To set up Laravel Doctrine ACL in Lumen, we need some additional steps.
 Install this package with composer:
 
 ```
-composer require "laravel-doctrine/migrations:1.0.*"
+composer require "laravel-doctrine/migrations"
 ```
 
 After updating composer, open `bootstrap/app.php` and register the Service Provider after `LaravelDoctrine\ORM\DoctrineServiceProvider::class`


### PR DESCRIPTION
I ran into issues installing for lumen because the docs specify an outdated version for the migrations package. Removing the version number should default to the latest release. 