### PR TITLE
Remove unneccesary character

### DIFF
--- a/extensions/sortable.md
+++ b/extensions/sortable.md
@@ -1,6 +1,6 @@
 # Sortable
 
-**Sortable** behavior will maintain a position field for ordering entities.\
+**Sortable** behavior will maintain a position field for ordering entities.
 
 - Automatic handling of position index
 - Group entity ordering by one or more fields


### PR DESCRIPTION
Remove a `\` that probably appeared accidentally in the docs.