### PR TITLE
Fix typo: "Berberlei" => "Beberlei"

### DIFF
--- a/extensions/installation.md
+++ b/extensions/installation.md
@@ -6,7 +6,7 @@ Install this package with composer:
 composer require "laravel-doctrine/extensions:1.0.*"
 ```
 
-This package wraps extensions from [Gedmo](https://github.com/Atlantic18/DoctrineExtensions) and [Berberlei](https://github.com/beberlei/DoctrineExtensions).
+This package wraps extensions from [Gedmo](https://github.com/Atlantic18/DoctrineExtensions) and [Beberlei](https://github.com/beberlei/DoctrineExtensions).
 
 To include Gedmo extensions install them:
 
@@ -28,7 +28,7 @@ To include Beberlei (Query/Type) extensions install them:
 composer require "beberlei/DoctrineExtensions=^1.0"
 ```
 
-And then add the Berberlei extensions service provider in `config/app.php`:
+And then add the Beberlei extensions service provider in `config/app.php`:
 
 
 ```php

--- a/extensions/introduction.md
+++ b/extensions/introduction.md
@@ -17,7 +17,7 @@ of Doctrine2 and handle the records being flushed in the behavioral way
 * __Tree__ - this extension automates the tree handling process and adds some tree specific functions on repository. (closure, nestedset or materialized path)
 * __Uploadable__ - provides file upload handling in entity fields
 
-### Query/Type extensions (Berberlei)
+### Query/Type extensions (Beberlei)
 
 A set of extensions to Doctrine 2 that add support for additional queryfunctions available in MySQL and Oracle.
 

--- a/extensions/lumen.md
+++ b/extensions/lumen.md
@@ -31,7 +31,7 @@ To include Beberlei (Query/Type) extensions install them:
 composer require "beberlei/DoctrineExtensions=^1.0"
 ```
 
-And then add the Berberlei extensions service provider in `bootstrap/app.php`:
+And then add the Beberlei extensions service provider in `bootstrap/app.php`:
 
 
 ```php


### PR DESCRIPTION
I wasn't quite sure best way to do this since the current default docs version is '1.3' at https://laraveldoctrine.org and neither '1.4'  or '1.5' are available in the upper right hand version pulldown.  Ergo, I didn't know if I should submit separate PRs for 1.3 and 1.4, or just push this up for 1.5 only.

How far back do you want to go with the versioned branches in fixing up typos and such?

FWIW, this typo goes all the way back to the 1.0 branch.