### PR TITLE
Update extension installation instructions

### DIFF
--- a/extensions/installation.md
+++ b/extensions/installation.md
@@ -21,6 +21,8 @@ If you are using an **annotation driver**, then add the Gedmo (Behavioral) exten
 LaravelDoctrine\Extensions\GedmoExtensionsServiceProvider::class,
 ```
 
+Also be sure to enable the extensions in the `extensions` section of `config/doctrine.php`.
+
 To include Beberlei (Query/Type) extensions install them:
 
 ```


### PR DESCRIPTION
The extension installation instructions do not call out the need to enable extensions in config/doctrine.php (as pointed out in this comment: https://github.com/laravel-doctrine/extensions/issues/36#issuecomment-357116168).  

This update adds a single sentence to call out the need to do so. 